### PR TITLE
Stabilize v0.1.0 outbox lease tests

### DIFF
--- a/apps/service/src/index.test.ts
+++ b/apps/service/src/index.test.ts
@@ -218,10 +218,12 @@ describe("local service and outbox worker", () => {
     const plane = new FakePlaneAdapter();
     plane.delayMs = 70;
     plane.delayOperation = "createItem";
+    const renewBatchLease = storageA.renewBatchLease.bind(storageA);
+    const renew = vi.spyOn(storageA, "renewBatchLease").mockImplementation((batchId, claimToken) => renewBatchLease(batchId, claimToken, 1_000));
     const workerA = new OutboxWorker(storageA, new EventCoordinator(storageA, plane));
     const workerB = new OutboxWorker(storageB, new EventCoordinator(storageB, plane));
     const firstRun = workerA.processOnce();
-    await new Promise((resolve) => setTimeout(resolve, 35));
+    await vi.waitFor(() => expect(renew).toHaveBeenCalled());
     expect(await workerB.processOnce()).toBe(0);
     expect(await firstRun).toBe(1);
     expect(plane.calls.filter((call) => call.startsWith("create:")).length).toBe(1);

--- a/packages/storage/src/index.test.ts
+++ b/packages/storage/src/index.test.ts
@@ -264,7 +264,7 @@ describe("SQLite storage", () => {
     const firstClaim = first.claimPendingBatches()[0]!;
     expect(second.claimPendingBatches()).toHaveLength(0);
     await new Promise((resolve) => setTimeout(resolve, 15));
-    const secondClaim = second.claimPendingBatches()[0]!;
+    const secondClaim = second.claimPendingBatches(1, 1_000)[0]!;
     expect(secondClaim.claimToken).not.toBe(firstClaim.claimToken);
     expect(first.renewBatchLease(secondClaim.id, firstClaim.claimToken!)).toBe(false);
     expect(() => first.markEventCompleted("event_1_0", "stale-item", firstClaim.claimToken)).toThrow("claim lost");


### PR DESCRIPTION
## Summary

- keep the stale-owner lease test short while giving the replacement owner enough time to complete assertions
- wait for an observed heartbeat renewal before checking that a second worker cannot claim the same batch

## Verification

- targeted lease tests passed 10 consecutive local runs
- all 123 tests and TypeScript checks pass
- the identical resulting tree passed all five native platform jobs in run 32004964233