### PR TITLE
Fix v0.1.0 Release publishing

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -176,6 +176,7 @@ jobs:
 
       - name: Create or update GitHub Release
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |

--- a/packages/storage/src/index.test.ts
+++ b/packages/storage/src/index.test.ts
@@ -272,7 +272,7 @@ describe("SQLite storage", () => {
     expect(second.getSourceReference("event_1_0")?.projectionStatus).toBe("pending");
     expect(second.setBatchStatus(secondClaim.id, "synced", undefined, firstClaim.claimToken)).toBe(false);
     expect(second.setBatchStatus(secondClaim.id, "failed", "stale", firstClaim.claimToken)).toBe(false);
-    expect(second.renewBatchLease(secondClaim.id, secondClaim.claimToken!)).toBe(true);
+    expect(second.renewBatchLease(secondClaim.id, secondClaim.claimToken!, 1_000)).toBe(true);
     second.markEventCompleted("event_1_0", "new-item", secondClaim.claimToken);
     expect(second.setBatchStatus(secondClaim.id, "synced", undefined, secondClaim.claimToken)).toBe(true);
     expect(second.listPendingBatches()).toHaveLength(0);


### PR DESCRIPTION
Explicitly sets GH_REPO in the publishing job so the GitHub CLI can create or update a Release without a checked-out Git repository.

This fixes the final publishing step from tag workflow run 32005723956; all five platform build and smoke-test jobs in that run passed.